### PR TITLE
Update drupal-org.make

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -12,8 +12,12 @@ defaults[projects][subdir] = "contrib"
 projects[] = admin_menu
 projects[] = admin_views
 projects[] = advagg
+projects[asset][type] = module
+projects[asset][download][type] = git
+projects[asset][download][revision] = e4a40eeb4553da886596d4de760fe95e131653fe
+projects[asset][download][branch] = 7.x-1.x
 ; @see https://www.drupal.org/node/2480503#comment-10332267
-projects[asset][patch][] = "https://www.drupal.org/files/issues/2480503-1-asset-add_more_icons-7.x-1.0-beta4.patch"
+projects[asset][patch][] = "https://www.drupal.org/files/issues/2480503-1-asset-add_more_icons-7.x-1.x.patch"
 ; @see https://www.drupal.org/node/2174613#comment-10425469
 projects[asset][patch][] = "https://www.drupal.org/files/issues/asset-youtube-video-2174613-5.patch"
 projects[] = bear_habitat


### PR DESCRIPTION
Downloading dev version of asset and pinning to a specific commit for stability. Doing this so asset patches will apply properly.
