### PR TITLE
Updating behat drupal extension and some new tests

### DIFF
--- a/tests/features/ContentCreationDefaults.feature
+++ b/tests/features/ContentCreationDefaults.feature
@@ -1,0 +1,16 @@
+@api
+Feature: Content Creation Defaults
+  When I create a piece of content
+  The preview option should be disabled
+  And the revision option should be enabled
+  And display author information should be disabled
+  And comments should be hidden
+
+Scenario: The Bear Necessities default settings for content creation are enforced
+Given I am logged in as a user with the "administrator" role
+ When I visit "admin/structure/types/manage/page"
+  Then the "edit-node-preview-0" radio button should be checked
+  And the "edit-node-options-status" checkbox should be checked
+  And the "edit-node-options-revision" checkbox should be checked
+  And the "edit-node-submitted" checkbox should not be checked
+  And the "edit-diff-enable-revisions-page-node" checkbox should be checked

--- a/tests/features/MultipleFieldWidget.feature
+++ b/tests/features/MultipleFieldWidget.feature
@@ -8,7 +8,7 @@ Feature: Multiple Field Widget
 Scenario: As an Administrator I can add a multiple text field to page content type and it is orderable.
   Given I am logged in as a user with the "administrator" role
    When I visit "admin/structure/types/manage/page/fields"
-    And I fill in "fields[_add_new_field][label]" with "Test field"
+    And I fill in "edit-fields-add-new-field-label" with "Test field"
     And I fill in "edit-fields-add-new-field-field-name" with "test"
     And I select "Text" from "edit-fields-add-new-field-type"
     And I select "text_textfield" from "edit-fields-add-new-field-widget-type"
@@ -24,7 +24,7 @@ Scenario: As an Administrator I can add a multiple text field to page content ty
 Scenario: As an Administrator I can add a multiple text field to page content type and it is not orderable.
   Given I am logged in as a user with the "administrator" role
    When I visit "admin/structure/types/manage/page/fields"
-    And I fill in "fields[_add_new_field][label]" with "Test field"
+    And I fill in "edit-fields-add-new-field-label" with "Test field"
     And I fill in "edit-fields-add-new-field-field-name" with "test"
     And I select "Text" from "edit-fields-add-new-field-type"
     And I select "text_textfield" from "edit-fields-add-new-field-widget-type"
@@ -42,13 +42,13 @@ Scenario: As an Administrator I can add a multiple text field to page content ty
 Scenario: As an administrator I can see an Orderable checkbox on multiple field
   Given I am logged in as a user with the "administrator" role
    When I visit "admin/structure/types/manage/page/fields"
-    And I fill in "fields[_add_new_field][label]" with "Test field"
+    And I fill in "edit-fields-add-new-field-label" with "Test field"
     And I fill in "edit-fields-add-new-field-field-name" with "test"
     And I select "Text" from "edit-fields-add-new-field-type"
     And I select "text_textfield" from "edit-fields-add-new-field-widget-type"
     And I press "Save"
     And I press "edit-submit"
     And I select "Unlimited" from "edit-field-cardinality"
-    And I press "Save settings" 
+    And I press "Save settings"
     And I visit "admin/structure/types/manage/page/fields/field_test/widget-type"
    Then I should see "Orderable"

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -111,58 +111,6 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
-   * @Given /^I switch to the iframe "([^"]*)"$/
-   *
-   * Drupal Media Module 7.x-1.3
-   */
-  public function switchToIFrame($name) {
-    if ($name) {
-      $this->getMainContext()->getSession()->switchToIFrame($name);
-    } else {
-      $this->getMainContect()->getSession()->switchToIFrame();
-    }
-  }
-
-  /**
-   * @Given /^I enter the media upload window$/
-   * @When I enter the iframe
-   */
-  public function iEnterTheIframe($arg1 = 'mediaBrowser') {
-    $this->getSession()->switchToIFrame($arg1);
-  }
-
-  /**
-   * @Given /^I leave the iframe$/
-   */
-  public function iLeaveTheIframe() {
-    $this->getSession()->switchToIFrame();
-    $this->getSession()->wait(3000, 'false');
-  }
-
-  /**
-   * @When I choose an image
-   * @When I choose a video
-   */
-  public function iChooseAnImage() {
-    $this->getSession()
-      ->getPage()
-      ->find("css", "#media-browser-library-list li img")
-      ->click();
-    $this->getSession()->wait(3000, 'false');
-  }
-
-  /**
-   * @When I choose an image from WYSIWYG media 
-   * @When I choose a video from WYSIWYG media 
-   */
-  public function iChooseAnImageFromWYSIWYGMedia() {
-    $this->getSession()->getDriver()
-      ->find("xpath", "//ul[@id='media-browser-library-list']/li/img")
-      ->click();
-  }
-
-
-  /**
    * @Given /^I click the fake "([^"]*)" button$/
    */
   public function iClickTheFakeButton($text) {

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -365,7 +365,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    */
   public function deleteTestField() {
     $driver = $this->getSession()->getDriver();
-    $driver->visit("admin/structure/types/manage/page/fields/field_test/delete");
+    $driver->visit("/admin/structure/types/manage/page/fields/field_test/delete");
     $this->getSession()->getPage()->pressButton("Delete");
   }
   


### PR DESCRIPTION
This is a bit of a bloated feature branch, but it includes an update to the Behat Drupal extension for 7.x and a test for defaults when creating new content types in Bear.
