### PR TITLE
Add components module to base install

### DIFF
--- a/bear.info.yml
+++ b/bear.info.yml
@@ -50,6 +50,7 @@ dependencies:
   - paragraphs
   - pathauto
   - token
+  - components
 themes:
   - bear_coat
   - bear_skin

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -49,6 +49,8 @@ projects[simple_sitemap][version] = "1.2"
 
 projects[token][version] = "1.0-beta1"
 
+projects[components][version] = "1.0"
+
 ; Libraries.
 
 ; Themes.


### PR DESCRIPTION
Components module is used to help with theming for D8 websites. It will be used on all sites that are based off bear_skin
